### PR TITLE
Store CircleCI coverage report as artifact

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,5 +7,10 @@ jobs:
         steps:
             - checkout
             - run:
-                name: Install All Node Dependencies and Run Unit Test Coverage
-                command: npm ci && npm run coverage
+                name: Install All Node Dependencies
+                command: npm ci 
+            - run:
+                name: Run Unit Test Coverage and Collect Coverage Reports
+                command: npm run coverage
+            - store_artifacts:
+                path: coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
     build:
         docker:
-            - image: node:10.10.0-alpine
+            - image: richmartinez/alpine-node-ca:1.0.0
         steps:
             - checkout
             - run:


### PR DESCRIPTION
* Update the CircleCI config to store the Jest coverage report as an artifact.

-------------------------------------------------------
- [x] Is a bulleted list of changes included?
- [x] Has all the related documentation been updated?
- [x] Have the unit tests been updated if necessary?
